### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "ubmannheim/publist4ubma2",
+    "type": "typo3-cms-extension",
+    "description": "TYPO3 extension which shows publications from an EPrints repository",
+    "keywords": [
+        "TYPO3",
+        "extension",
+        "EPrints"
+    ],
+    "homepage": "https://github.com/UB-Mannheim/publist4ubma2",
+    "support": {
+        "issues": "https://github.com/UB-Mannheim/publist4ubma2/issues",
+        "wiki": "https://github.com/UB-Mannheim/publist4ubma2/wiki"
+    },
+    "authors": [
+        {
+            "name": "Sebastian Kotthoff",
+            "email": "sebastian.kotthoff@rz.uni-mannheim.de",
+            "role": "Developer",
+            "homepage": "http://dws.informatik.uni-mannheim.de/en/people/administration/sebastiankotthoff/"
+        }
+    ],
+    "license": "GPL-2.0",
+    "require": {
+        "typo3/cms-core": ">=6.2.0 <=7.6.99"
+    },
+    "autoload": {
+        "psr-4": {
+            "Unima\\Publist4ubma2\\": "Classes"
+        }
+    },
+    "replace": {
+        "publist4ubma2": "self.version",
+        "typo3-ter/publist4ubma2": "self.version"
+    }
+}


### PR DESCRIPTION
A composer.json file is especially useful for defining any dependencies in a standardized form. Moreover, it should allow installing the extension with [composer](https://getcomposer.org/), see https://usetypo3.com/typo3-and-composer.html . Moreover, we can think about deploy it to [packagist](https://packagist.org/). And finally, we might need such a file also for any automatic tests with Travis CI.