### PR TITLE
Use number instead of revNumber

### DIFF
--- a/Classes/Controller/PublicationController.php
+++ b/Classes/Controller/PublicationController.php
@@ -279,11 +279,11 @@ class PublicationController extends BasicPublistController {
 			$this->debugger->add('Publication ' . $publication['eprintid'] . ' has no publisher');
 		}
 
-		if ($publication['rev_number'])
-			$newPub->setRevNumber($publication['rev_number']);
+		if ($publication['number'])
+			$newPub->setNumber($publication['number']);
 		else {
-			$newPub->setRevNumber("");
-			$this->debugger->add('Publication ' . $publication['eprintid'] . ' has no rev_number');
+			$newPub->setNumber("");
+			$this->debugger->add('Publication ' . $publication['eprintid'] . ' has no number');
 		}
 
 		if ($publication['publication'])

--- a/Classes/Controller/PublicationController.php
+++ b/Classes/Controller/PublicationController.php
@@ -577,14 +577,10 @@ class PublicationController extends BasicPublistController {
 			$coin .= "&rft.volume=" . rawurlencode($pub->getVolume());
 		}
 
-/*
-		// field not in typo3 DB yet, forgotten, have to add it
-		
 		//number --> issue
-		if ( isset($pubListArray["$index"][number]) ) {
-			$coin .= "&rft.issue=" . rawurlencode($pubListArray["$index"][number]);
+		if ( $pub->getNumber() != "" ) {
+			$coin .= "&rft.issue=" . rawurlencode($pub->getNumber());
 		}
-*/
 
 		//pagerange --> pages
 		if ( $pub->getPageRange() != "" ) {

--- a/Classes/Domain/Model/Publication.php
+++ b/Classes/Domain/Model/Publication.php
@@ -168,11 +168,11 @@ class Publication extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
 	protected $publisher = '';
 
 	/**
-	 * revNumber
+	 * number
 	 *
 	 * @var string
 	 */
-	protected $revNumber = '';
+	protected $number = '';
 
 	/**
 	 * publication
@@ -529,22 +529,22 @@ class Publication extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
 	}
 
 	/**
-	 * Returns the revNumber
+	 * Returns the number
 	 *
-	 * @return string $revNumber
+	 * @return string $number
 	 */
-	public function getRevNumber() {
-		return $this->revNumber;
+	public function getNumber() {
+		return $this->number;
 	}
 
 	/**
-	 * Sets the revNumber
+	 * Sets the number
 	 *
-	 * @param string $revNumber
+	 * @param string $number
 	 * @return void
 	 */
-	public function setRevNumber($revNumber) {
-		$this->revNumber = $revNumber;
+	public function setNumber($number) {
+		$this->number = $number;
 	}
 
 	/**

--- a/Configuration/TCA/tx_publist4ubma2_domain_model_publication.php
+++ b/Configuration/TCA/tx_publist4ubma2_domain_model_publication.php
@@ -19,14 +19,14 @@ return array(
 			'starttime' => 'starttime',
 			'endtime' => 'endtime',
 		),
-		'searchFields' => 'eprint_id,title,abstract,url_offical,url_ubma_extern,used_link_url,url,year,bib_type,volume,publisher,rev_number,publication,editors,creators,corp_creators,ubma_book_editor,event_location,place_of_pub,page_range,issn,isbn,ubma_tags,ubma_edition,book_title,used_coin,id_number',
+		'searchFields' => 'eprint_id,title,abstract,url_offical,url_ubma_extern,used_link_url,url,year,bib_type,volume,publisher,number,publication,editors,creators,corp_creators,ubma_book_editor,event_location,place_of_pub,page_range,issn,isbn,ubma_tags,ubma_edition,book_title,used_coin,id_number',
 		'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('publist4ubma2') . 'Resources/Public/Icons/tx_publist4ubma2_domain_model_publication.gif'
 	),
 	'interface' => array(
-		'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, rev_number, publication, editors, creators, corp_creators, ubma_book_editor, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, book_title, used_coin, id_number',
+		'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, number, publication, editors, creators, corp_creators, ubma_book_editor, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, book_title, used_coin, id_number',
 	),
 	'types' => array(
-		'1' => array('showitem' => 'sys_language_uid;;;;1-1-1, l10n_parent, l10n_diffsource, hidden;;1, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, rev_number, publication, editors, creators, corp_creators, ubma_book_editor, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, book_title, used_coin,id_number , --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'),
+		'1' => array('showitem' => 'sys_language_uid;;;;1-1-1, l10n_parent, l10n_diffsource, hidden;;1, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, number, publication, editors, creators, corp_creators, ubma_book_editor, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, book_title, used_coin,id_number , --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'),
 	),
 	'palettes' => array(
 		'1' => array('showitem' => ''),
@@ -224,9 +224,9 @@ return array(
 				'eval' => 'trim'
 			),
 		),
-		'rev_number' => array(
+		'number' => array(
 			'exclude' => 1,
-			'label' => 'LLL:EXT:publist4ubma2/Resources/Private/Language/locallang_db.xlf:tx_publist4ubma2_domain_model_publication.rev_number',
+			'label' => 'LLL:EXT:publist4ubma2/Resources/Private/Language/locallang_db.xlf:tx_publist4ubma2_domain_model_publication.number',
 			'config' => array(
 				'type' => 'input',
 				'size' => 30,

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -68,8 +68,8 @@
 			<trans-unit id="tx_publist4ubma2_domain_model_publication.publisher">
 				<source>Publisher</source>
 			</trans-unit>
-			<trans-unit id="tx_publist4ubma2_domain_model_publication.rev_number">
-				<source>Rev Number</source>
+			<trans-unit id="tx_publist4ubma2_domain_model_publication.number">
+				<source>Number</source>
 			</trans-unit>
 			<trans-unit id="tx_publist4ubma2_domain_model_publication.publication">
 				<source>Publication</source>

--- a/Resources/Private/Language/locallang_csh_tx_publist4ubma2_domain_model_publication.xlf
+++ b/Resources/Private/Language/locallang_csh_tx_publist4ubma2_domain_model_publication.xlf
@@ -33,8 +33,8 @@
 			<trans-unit id="publisher.description">
 				<source>publisher</source>
 			</trans-unit>
-			<trans-unit id="rev_number.description">
-				<source>revNumber</source>
+			<trans-unit id="number.description">
+				<source>number</source>
 			</trans-unit>
 			<trans-unit id="publication.description">
 				<source>publication</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -69,8 +69,8 @@
 			<trans-unit id="tx_publist4ubma2_domain_model_publication.publisher">
 				<source>Publisher</source>
 			</trans-unit>
-			<trans-unit id="tx_publist4ubma2_domain_model_publication.rev_number">
-				<source>Rev Number</source>
+			<trans-unit id="tx_publist4ubma2_domain_model_publication.number">
+				<source>Number</source>
 			</trans-unit>
 			<trans-unit id="tx_publist4ubma2_domain_model_publication.publication">
 				<source>Publication</source>

--- a/Resources/Private/Partials/FrontendBibCoinTemplate.html
+++ b/Resources/Private/Partials/FrontendBibCoinTemplate.html
@@ -3,7 +3,7 @@
 	<f:case value="article">
 		<span class='Z3988' title='{publication.usedCoin}'></span><m:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external> </strong>.
-		<em>{publication.publication}</em>, {publication.volume}, {publication.revNumber}, {publication.pageRange}.
+		<em>{publication.publication}</em>, {publication.volume}, {publication.number}, {publication.pageRange}.
 	</f:case>
 	<f:case value="book">
 		<span class='Z3988' title='{publication.usedCoin}'></span><m:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):

--- a/Resources/Private/Partials/FrontendDWSrdfaSchema.html
+++ b/Resources/Private/Partials/FrontendDWSrdfaSchema.html
@@ -57,7 +57,7 @@
 		<span  prefix="schema: http://schema.org/" about="http://ub-madoc.bib.uni-mannheim.de/'{publication.eprintId}'" typeOf="schema:ScholarlyArticle">
 		<m:renderNamesWithAndRdfaSchema somebody="{publication.creators}" />
 		<strong><span property="schema:name"><f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external></span>.</strong>
-		<span property="schema:isPartOf"  typeOf="schema:PublicationVolume"><span property="schema:name">{publication.publication}</span></span> ({publication.revNumber}),
+		<span property="schema:isPartOf"  typeOf="schema:PublicationVolume"><span property="schema:name">{publication.publication}</span></span> ({publication.number}),
 		<span property="schema:publisher" typeOf="schema:Organization"><span property="schema:name">{publication.publisher}</span></span>,
 		<span property="schema:contentLocation" typeOf="schema:Place"><span property="schema:name">{publication.placeOfPub}</span></span>, <span property="schema:datePublished">{publication.year}</span></span>.
 	</f:case>

--- a/Resources/Private/Partials/FrontendDefaultTemplate.html
+++ b/Resources/Private/Partials/FrontendDefaultTemplate.html
@@ -10,7 +10,7 @@
 		<m:renderNamesWithAnd somebody="{publication.creators}" />.
 		{publication.corpCreators} {publication.year}
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external> </strong>
-		<em>{publication.publication},</em> {publication.volume}, {publication.revNumber}, {publication.pageRange}<br />{publication.abstract}
+		<em>{publication.publication},</em> {publication.volume}, {publication.number}, {publication.pageRange}<br />{publication.abstract}
 	</f:case>
 	<f:case value="book_section">
 		<m:renderNamesWithAnd somebody="{publication.creators}" />.
@@ -43,7 +43,7 @@
 		<m:renderNamesWithAnd somebody="{publication.creators}" />.
 		{publication.publisher}, {publication.corpCreators} {publication.year}
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external> </strong>
-		{publication.publication}, {publication.volume}, {publication.revNumber}, {publication.placeOfPub}<br />{publication.abstract}
+		{publication.publication}, {publication.volume}, {publication.number}, {publication.placeOfPub}<br />{publication.abstract}
 	</f:case>
 	<f:case value="other">
 		<m:renderNamesWithAnd somebody="{publication.creators}" />.
@@ -66,7 +66,7 @@
 	<f:case value="review">
 		<m:renderNamesWithAnd somebody="{publication.creators}" />. {publication.publisher},
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}.</f:link.external></strong>
-		{publication.publication}, {publication.volume}, {publication.revNumber}, {publication.pageRange}<br />{publication.abstract}
+		{publication.publication}, {publication.volume}, {publication.number}, {publication.pageRange}<br />{publication.abstract}
 	</f:case>
 	<f:case value="thesis">
 		<m:renderNamesWithAnd somebody="{publication.creators}" />. {publication.year}

--- a/Resources/Private/Partials/FrontendTableDebug.html
+++ b/Resources/Private/Partials/FrontendTableDebug.html
@@ -11,7 +11,7 @@
 	<tr><td>ubmaTags</td><td>{publication.ubmaTags}</td></tr>
 	<tr><td>bibType</td><td>{publication.bibType}</td></tr>
 	<tr><td>volume</td><td>{publication.volume}</td></tr>
-	<tr><td>revNumber</td><td>{publication.revNumber}</td></tr>
+	<tr><td>number</td><td>{publication.number}</td></tr>
 	<tr><td>publication</td><td>{publication.publication}</td></tr>
 	<tr><td>editors</td><td>{publication.editors}</td></tr>
 	<tr><td>creators</td><td>{publication.creators}</td></tr>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -146,7 +146,7 @@ CREATE TABLE tx_publist4ubma2_domain_model_publication (
 	bib_type varchar(255) DEFAULT '' NOT NULL,
 	volume varchar(255) DEFAULT '' NOT NULL,
 	publisher varchar(255) DEFAULT '' NOT NULL,
-	rev_number varchar(255) DEFAULT '' NOT NULL,
+	number varchar(255) DEFAULT '' NOT NULL,
 	publication varchar(255) DEFAULT '' NOT NULL,
 	editors varchar(255) DEFAULT '' NOT NULL,
 	creators varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
This replaces all occurrences of
 * revNumber -> number
 * rev_number -> number

The revNumber is the number of revisions which are made
in MADOC for this entry, but we want the number/issue
information as a bibliographic metadata element for
journal articles or individual jounral items.