### PR TITLE
Replace all occurrences of apostrophe (not only first one)

### DIFF
--- a/Resources/Public/JavaScript/uma_publist.js
+++ b/Resources/Public/JavaScript/uma_publist.js
@@ -6,7 +6,7 @@ $.expr[":"].contains = $.expr.createPseudo(function(arg) {
 
 $(document).ready(function() {
 	var updateUmaPublist = function(content, searchWord) {
-		searchWord = searchWord.replace(/'/, '');
+		searchWord = searchWord.replace(/'/g, '');
 		$(this).find('li').addClass('hidden').filter(":contains('" + searchWord + "')").removeClass('hidden');
 	};
 	$('.uma-publist-filter').on('keyup', function() {


### PR DESCRIPTION
This fixes an error reported by LGTM:

    This replaces only the first occurrence of /'/.

Signed-off-by: Stefan Weil <sw@weilnetz.de>