### PR TITLE
Improve rendering of thesis in APA

### DIFF
--- a/Resources/Private/Partials/FrontendAPA.html
+++ b/Resources/Private/Partials/FrontendAPA.html
@@ -128,7 +128,7 @@
 	</f:case>
 	<f:case value="dissertation">
 		{n:renderNamesApa(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>{titleDot}
-		Dissertation, {publication.publisher->v:format.trim(characters: '.')}. {publication.placeOfPub}
+		[Dissertation].
 	</f:case>
 	<f:case value="encyclopedia_article">
 		{n:renderNamesApa(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>{titleDot}

--- a/Resources/Private/Partials/FrontendAPA.html
+++ b/Resources/Private/Partials/FrontendAPA.html
@@ -127,7 +127,7 @@
 		{publication.publisher}: {publication.placeOfPub}.
 	</f:case>
 	<f:case value="dissertation">
-		{n:renderNamesApa(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>{titleDot}
+		{n:renderNamesApa(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>
 		[Dissertation].
 	</f:case>
 	<f:case value="encyclopedia_article">


### PR DESCRIPTION
Currently, in the APA template we have for a thesis the following output
```
Weber, T. (2020). Präpositionen und Deutsch als Fremdsprache: Quantitative Fall­studien im Lernerkorpus MERLIN. Dissertation, . Mannheim. 
```
It expect a publisher but that is usually not present for thesis and would not be displayed in APA. Moreover, the place is not needed. The type should go into parenthesis followed by the university, e.g. in English one would have `[Doctoral dissertation, University of Mannheim]`. The university variable in MADOC is exported as `ubma_university` which we would need to make available to the plugin first. This commit is only partially solve this by resulting
```
Weber, T. (2020). Präpositionen und Deutsch als Fremdsprache: Quantitative Fall­studien im Lernerkorpus MERLIN [Dissertation].
```
In a follow up one could improve this into
```
Weber, T. (2020). Präpositionen und Deutsch als Fremdsprache: Quantitative Fall­studien im Lernerkorpus MERLIN [Dissertation, Universität Mannheim].
```
But there one would need the new variable and should introduce a language-depend string "Dissertation" = "Doctoral dissertation". See also https://apastyle.apa.org/style-grammar-guidelines/references/examples/published-dissertation-references