### PR TITLE
No series title for conference item

### DIFF
--- a/Resources/Private/Partials/FrontendAPA.html
+++ b/Resources/Private/Partials/FrontendAPA.html
@@ -123,7 +123,7 @@
 				</f:if>
 			</f:else>
 		</f:if>
-		{publication.bookTitle} (S. {publication.pageRange}). <em>{publication.publication}</em>,
+		<em>{publication.bookTitle}</em> (S. {publication.pageRange}). 
 		{publication.publisher}: {publication.placeOfPub}.
 	</f:case>
 	<f:case value="dissertation">


### PR DESCRIPTION
The publication.publication variable is anyway in a lot of cases empty and therefore procuding artefacts like `. , `.
This fixes these cases as well. Moreover, it puts the book title for conference item in italics.