### PR TITLE
Remove "ubma_book_editor"

### DIFF
--- a/Classes/Controller/PublicationController.php
+++ b/Classes/Controller/PublicationController.php
@@ -306,13 +306,6 @@ class PublicationController extends BasicPublistController {
 			$this->debugger->add('Publication ' . $publication['eprintid'] . ' has no place_of_pub');
 		}
 
-		if ($publication['ubma_book_editor']) {
-			$newPub->setUbmaBookEditor($publication['ubma_book_editor']['family'] . ',' . $publication['ubma_book_editor']['given']);
-		} else {
-			$newPub->setUbmaBookEditor("");
-			$this->debugger->add('Publication ' . $publication['eprintid'] . ' has no ubma_book_editor');
-		}
-
 		if ($publication['pagerange']) {
 			$newPub->setPageRange($publication['pagerange']);
 		} else {

--- a/Configuration/TCA/tx_umapublist_domain_model_publication.php
+++ b/Configuration/TCA/tx_umapublist_domain_model_publication.php
@@ -19,14 +19,14 @@ return array(
 			'starttime' => 'starttime',
 			'endtime' => 'endtime',
 		),
-		'searchFields' => 'eprint_id,title,abstract,year,bib_type,volume,publisher,number,publication,editors,creators,corp_creators,ubma_book_editor,event_location,place_of_pub,issn,isbn,ubma_tags,ubma_edition,book_title,used_coin,doi,urn,event_title,',
+		'searchFields' => 'eprint_id,title,abstract,year,bib_type,volume,publisher,number,publication,editors,creators,corp_creators,event_location,place_of_pub,issn,isbn,ubma_tags,ubma_edition,book_title,used_coin,doi,urn,event_title,',
 		'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('uma_publist') . 'Resources/Public/Icons/tx_umapublist_domain_model_publication.gif'
 	),
 	'interface' => array(
-		'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, number, publication, editors, creators, corp_creators, ubma_book_editor, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, ubma_forthcoming, ubma_university, book_title, used_coin, doi, urn, event_title',
+		'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, number, publication, editors, creators, corp_creators, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, ubma_forthcoming, ubma_university, book_title, used_coin, doi, urn, event_title',
 	),
 	'types' => array(
-		'1' => array('showitem' => 'sys_language_uid;;;;1-1-1, l10n_parent, l10n_diffsource, hidden;;1, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, number, publication, editors, creators, corp_creators, ubma_book_editor, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, ubma_forthcoming, ubma_university, book_title, used_coin, doi, urn, event_title, --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'),
+		'1' => array('showitem' => 'sys_language_uid;;;;1-1-1, l10n_parent, l10n_diffsource, hidden;;1, eprint_id, title, abstract, url_offical, url_ubma_extern, used_link_url, url, year, bib_type, volume, publisher, number, publication, editors, creators, corp_creators, event_location, place_of_pub, page_range, issn, isbn, ubma_tags, ubma_edition, ubma_forthcoming, ubma_university, book_title, used_coin, doi, urn, event_title, --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'),
 	),
 	'palettes' => array(
 		'1' => array('showitem' => ''),
@@ -270,15 +270,6 @@ return array(
 			),
 		),
 
-		'ubma_book_editor' => array(
-			'exclude' => 1,
-			'label' => 'LLL:EXT:uma_publist/Resources/Private/Language/locallang_db.xlf:tx_umapublist_domain_model_publication.ubma_book_editor',
-			'config' => array(
-				'type' => 'input',
-				'size' => 30,
-				'eval' => 'trim'
-			),
-		),
 		'event_location' => array(
 			'exclude' => 1,
 			'label' => 'LLL:EXT:uma_publist/Resources/Private/Language/locallang_db.xlf:tx_umapublist_domain_model_publication.eventLocation',

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -111,10 +111,6 @@
 				<source>CorpCreators</source>
 				<target>CorpCreators</target>
 			</trans-unit>
-			<trans-unit id="tx_umapublist_domain_model_publication.ubma_book_editor">
-				<source>UBMA Book Editor</source>
-				<target>UBMA Book Editor</target>
-			</trans-unit>
 			<trans-unit id="tx_umapublist_domain_model_publication.eventLocation">
 				<source>Event Location</source>
 				<target>Ort der Veranstaltung</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -84,9 +84,6 @@
 			<trans-unit id="tx_umapublist_domain_model_publication.corpCreators">
 				<source>CorpCreators</source>
 			</trans-unit>
-			<trans-unit id="tx_umapublist_domain_model_publication.ubma_book_editor">
-				<source>UBMA Book Editor</source>
-			</trans-unit>
 			<trans-unit id="tx_umapublist_domain_model_publication.eventLocation">
 				<source>Event Location</source>
 			</trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -158,7 +158,6 @@ CREATE TABLE tx_umapublist_domain_model_publication (
 	editors varchar(255) DEFAULT '' NOT NULL,
 	creators varchar(1000) DEFAULT '' NOT NULL,
 	corp_creators varchar(255) DEFAULT '' NOT NULL,
-	ubma_book_editor varchar(255) DEFAULT '' NOT NULL,
 	event_location varchar(255) DEFAULT '' NOT NULL,
 	event_title varchar(255) DEFAULT '' NOT NULL,
 	place_of_pub varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
The field is now obsolete in madoc and its values are now simply in "editors".

From having a glance at the code, I saw no need for further changes other than removing the field, but I didn't test it. This PR is merely a reminder really...