### PR TITLE
Update FrontendJura.html

### DIFF
--- a/Resources/Private/Partials/FrontendJura.html
+++ b/Resources/Private/Partials/FrontendJura.html
@@ -142,6 +142,9 @@
 	</f:case>
 	<f:defaultCase>
 		<em><n:renderLastNamesOnly somebody="{publication.creators}" /></em> <em><n:renderLastNamesOnly somebody="{publication.editors}" /></em> <em>{publication.corpCreators}</em>, <f:link.external uri="{publication.usedLinkUrl}" target="_blank"><n:deleteSpaceBeforeColon title="{publication.title}" /></f:link.external>,
-		<n:deleteSpaceBeforeColon title="{publication.publication}" />, {publication.year}.
+		<f:if condition="{publication.publication}">
+			<n:deleteSpaceBeforeColon title="{publication.publication}" />,
+		</f:if>
+		{publication.year}.
 	</f:defaultCase>
 </f:switch>


### PR DESCRIPTION
This will avoid to print to commas for the other case when there is no publication title given, e.g. https://madoc.bib.uni-mannheim.de/47693/.