### PR TITLE
Use editors instead of ubmaBookEditor

### DIFF
--- a/Resources/Private/Partials/FrontendBWLapa.html
+++ b/Resources/Private/Partials/FrontendBWLapa.html
@@ -32,11 +32,11 @@
 	</f:case>
 	<f:case value="book_section">
 		{n:renderNamesShort(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>{titleDot}
-		In <n:renderNamesShort somebody="{publication.ubmaBookEditor}"/> <em>{publication.bookTitle}</em> (S. {publication.pageRange}). {publication.placeOfPub}: {publication.publisher->v:format.trim(characters: '.')}.
+		In <n:renderNamesShort somebody="{publication.editors}"/> <em>{publication.bookTitle}</em> (S. {publication.pageRange}). {publication.placeOfPub}: {publication.publisher->v:format.trim(characters: '.')}.
 	</f:case>
 	<f:case value="conference_item">
 		{n:renderNamesShort(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>{titleDot}
-		In <n:renderNamesShort somebody="{publication.ubmaBookEditor}"/>, {publication.bookTitle} (S. {publication.pageRange}). <em>{publication.publication}</em>,
+		In <n:renderNamesShort somebody="{publication.editors}"/>, {publication.bookTitle} (S. {publication.pageRange}). <em>{publication.publication}</em>,
 		{publication.publisher}: {publication.placeOfPub}.
 	</f:case>
 	<f:case value="conference_presentation">
@@ -49,7 +49,7 @@
 	</f:case>
 	<f:case value="encyclopedia_article">
 		{n:renderNamesShort(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>{titleDot}
-		In <n:renderNamesShort somebody="{publication.ubmaBookEditor}"/>, <em>{publication.bookTitle}</em> (S. {publication.pageRange}). {publication.placeOfPub}: {publication.publisher->v:format.trim(characters: '.')}.
+		In <n:renderNamesShort somebody="{publication.editors}"/>, <em>{publication.bookTitle}</em> (S. {publication.pageRange}). {publication.placeOfPub}: {publication.publisher->v:format.trim(characters: '.')}.
 	</f:case>
 	<f:case value="habilitation">
 		{n:renderNamesShort(somebody: publication.creators)} ({publication.year}). <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external>{titleDot}

--- a/Resources/Private/Partials/FrontendBibCoinTemplate.html
+++ b/Resources/Private/Partials/FrontendBibCoinTemplate.html
@@ -16,17 +16,17 @@
 	<f:case value="book_section">
 		<span class='Z3988' title='{publication.usedCoin}'></span><n:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external> </strong>.
-		In: {publication.ubmaBookEditor} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
+		In: {publication.editors} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
 	</f:case>
 	<f:case value="conference_item">
 		<span class='Z3988' title='{publication.usedCoin}'></span><n:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external> </strong>.
-		In: {publication.ubmaBookEditor} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
+		In: {publication.editors} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
 	</f:case>
 	<f:case value="workshop_item">
 		<span class='Z3988' title='{publication.usedCoin}'></span><n:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external> </strong>.
-		In: {publication.ubmaBookEditor} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
+		In: {publication.editors} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
 	</f:case>
 	<f:case value="conference_presentation">
 		<span class='Z3988' title='{publication.usedCoin}'></span><n:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):
@@ -41,7 +41,7 @@
 	<f:case value="encyclopedia_article">
 		<span class='Z3988' title='{publication.usedCoin}'></span><n:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):
 		<strong> <f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external> </strong>.
-		In: {publication.ubmaBookEditor} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
+		In: {publication.editors} <em>{publication.bookTitle}</em>, {publication.placeOfPub} : {publication.publisher}, S. {publication.pageRange}.
 	</f:case>
 	<f:case value="habilitation">
 		<span class='Z3988' title='{publication.usedCoin}'></span><n:renderNamesWithAnd somebody="{publication.creators}" /> ({publication.year}):

--- a/Resources/Private/Partials/FrontendDWSrdfaSchema.html
+++ b/Resources/Private/Partials/FrontendDWSrdfaSchema.html
@@ -22,7 +22,7 @@
 		<span  prefix="schema: http://schema.org/" about="https://madoc.bib.uni-mannheim.de/'{publication.eprintId}'" typeof="schema:ScholarlyArticle">
 		<n:renderNamesWithAndRdfaSchema somebody="{publication.creators}" />
 		<strong><span property="schema:name"><span property="schema:name"><f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external></span></span>. </strong>
-		In: <n:renderNamesWithAndRdfaSchema somebody="{publication.ubmaBookEditor}" />,
+		In: <n:renderNamesWithAndRdfaSchema somebody="{publication.editors}" />,
 		<em><span property="schema:isPartOf" typeof="schema:Book"><span property="schema:name"><f:link.external uri="{publication.usedLinkUrl}" target="_blank">{publication.title}</f:link.external></span></span></em>;
 		<span property="schema:pagination">{publication.pageRange}</span>, <span property="schema:publisher" typeof="schema:Organization">
 		<span property="schema:name">{publication.publisher}</span></span>, <span property="schema:contentLocation" typeof="schema:Place"><span property="schema:name">{publication.placeOfPub}</span></span>,

--- a/Resources/Private/Partials/FrontendJura.html
+++ b/Resources/Private/Partials/FrontendJura.html
@@ -36,8 +36,8 @@
 	<f:case value="book_section">
 		<em><n:renderLastNamesOnly somebody="{publication.creators}" /></em>, <f:link.external uri="{publication.usedLinkUrl}" target="_blank"><n:deleteSpaceBeforeColon title="{publication.title}" /></f:link.external>, 
 		in:
-		<f:if condition="{publication.ubmaBookEditor}">
-			<n:renderLastNamesOnly somebody="{publication.ubmaBookEditor}" /> (Hrsg.),
+		<f:if condition="{publication.editors}">
+			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
 		</f:if>
 		<f:if condition="{publication.editors}">
 			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
@@ -51,8 +51,8 @@
 	<f:case value="kommentierung">
 		<em><n:renderLastNamesOnly somebody="{publication.creators}" /></em>, <f:link.external uri="{publication.usedLinkUrl}" target="_blank"><n:deleteSpaceBeforeColon title="{publication.title}" /></f:link.external>, 
 		in:
-		<f:if condition="{publication.ubmaBookEditor}">
-			<n:renderLastNamesOnly somebody="{publication.ubmaBookEditor}" /> (Hrsg.),
+		<f:if condition="{publication.editors}">
+			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
 		</f:if>
 		<f:if condition="{publication.editors}">
 			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
@@ -66,8 +66,8 @@
 	<f:case value="conference_item">
 		<em><n:renderLastNamesOnly somebody="{publication.creators}" /></em>, <f:link.external uri="{publication.usedLinkUrl}" target="_blank"><n:deleteSpaceBeforeColon title="{publication.title}" /></f:link.external>, 
 		in:
-		<f:if condition="{publication.ubmaBookEditor}">
-			<n:renderLastNamesOnly somebody="{publication.ubmaBookEditor}" /> (Hrsg.),
+		<f:if condition="{publication.editors}">
+			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
 		</f:if>
 		<f:if condition="{publication.editors}">
 			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
@@ -81,8 +81,8 @@
 	<f:case value="encyclopedia_article">
 		<em><n:renderLastNamesOnly somebody="{publication.creators}" /></em>, <f:link.external uri="{publication.usedLinkUrl}" target="_blank"><n:deleteSpaceBeforeColon title="{publication.title}" /></f:link.external>, 
 		in:
-		<f:if condition="{publication.ubmaBookEditor}">
-			<n:renderLastNamesOnly somebody="{publication.ubmaBookEditor}" /> (Hrsg.),
+		<f:if condition="{publication.editors}">
+			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
 		</f:if>
 		<f:if condition="{publication.editors}">
 			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
@@ -96,8 +96,8 @@
 	<f:case value="workshop_item">
 		<em><n:renderLastNamesOnly somebody="{publication.creators}" /></em>, <f:link.external uri="{publication.usedLinkUrl}" target="_blank"><n:deleteSpaceBeforeColon title="{publication.title}" /></f:link.external>, 
 		in:
-		<f:if condition="{publication.ubmaBookEditor}">
-			<n:renderLastNamesOnly somebody="{publication.ubmaBookEditor}" /> (Hrsg.),
+		<f:if condition="{publication.editors}">
+			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),
 		</f:if>
 		<f:if condition="{publication.editors}">
 			<n:renderLastNamesOnly somebody="{publication.editors}" /> (Hrsg.),

--- a/Resources/Private/Partials/FrontendTableDebug.html
+++ b/Resources/Private/Partials/FrontendTableDebug.html
@@ -17,7 +17,6 @@
 	<tr><td>creators</td><td>{publication.creators}</td></tr>
 	<tr><td>publisher</td><td>{publication.publisher}</td></tr>
 	<tr><td>corpCreators</td><td>{publication.corpCreators}</td></tr>
-	<tr><td>ubmaBookEditor</td><td>{publication.ubmaBookEditor}</td></tr>
 	<tr><td>eventLocation</td><td>{publication.eventLocation}</td></tr>
 	<tr><td>eventTitle</td><td>{publication.eventTitle}</td></tr>
 	<tr><td>placeOfPub</td><td>{publication.placeOfPub}</td></tr>


### PR DESCRIPTION
The field ubmaBookEditor is no longer valid but we use now the editors field in MADOC.
This replaces more occurences of the outdated field ubmaBookEditor by editors.