### PR TITLE
change wording for book sections / chapters

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -108,7 +108,7 @@
 				<target>Artikel</target>
 			</trans-unit>
 			<trans-unit id="book_section" xml:space="preserve">
-				<source>Book Sections</source>
+				<source>Book Chapters</source>
 				<target>Buchkapitel</target>
 			</trans-unit>
 			<trans-unit id="dissertation" xml:space="preserve">

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -213,7 +213,7 @@
 				<target>Bücher</target>
 			</trans-unit>
 			<trans-unit id="pi1_flexform.type.book_section" xml:space="preserve">
-				<source>Book Sections</source>
+				<source>Book Chapters</source>
 				<target>Buchkapitel</target>
 			</trans-unit>
 			<trans-unit id="pi1_flexform.type.conference_item" xml:space="preserve">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -82,7 +82,7 @@
 				<source>Articles</source>
 			</trans-unit>
 			<trans-unit id="book_section" xml:space="preserve">
-				<source>Book Sections</source>
+				<source>Book Chapters</source>
 			</trans-unit>
 			<trans-unit id="dissertation" xml:space="preserve">
 				<source>Dissertation</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -161,7 +161,7 @@
 				<source>Books</source>
 			</trans-unit>
 			<trans-unit id="pi1_flexform.type.book_section" xml:space="preserve">
-				<source>Book Sections</source>
+				<source>Book Chapters</source>
 			</trans-unit>
 			<trans-unit id="pi1_flexform.type.conference_item" xml:space="preserve">
 				<source>Conference Items</source>


### PR DESCRIPTION
Hi,

a colleague of mine complained to me, that the plugin should say "Book Chapters" instead of "Book Sections" for some reason, so I `sed`ed through the code. Take it or leave it. :D

Best regards
Dennis